### PR TITLE
Add a ClearAll method (cursor background agent generated)

### DIFF
--- a/dataloader_test.go
+++ b/dataloader_test.go
@@ -376,13 +376,12 @@ func TestLoader(t *testing.T) {
 	})
 
 	t.Run("allows clearAll values in cache", func(t *testing.T) {
-		t.Skip("not supported yet")
 		t.Parallel()
 		identityLoader, loadCalls := IDLoader(0)
 		identityLoader.Prime("A", "Cached")
 		identityLoader.Prime("B", "B")
 
-		// identityLoader.ClearAll()
+		identityLoader.ClearAll()
 
 		future1 := identityLoader.LoadThunk(ctx, "1")
 		future2 := identityLoader.LoadThunk(ctx, "A")

--- a/dataloadgen.go
+++ b/dataloadgen.go
@@ -286,6 +286,13 @@ func (l *Loader[KeyT, ValueT]) Clear(key KeyT) {
 	l.mu.Unlock()
 }
 
+// ClearAll clears all values from the cache
+func (l *Loader[KeyT, ValueT]) ClearAll() {
+	l.mu.Lock()
+	l.thunkCache = make(map[KeyT]func() (ValueT, error))
+	l.mu.Unlock()
+}
+
 func (l *Loader[KeyT, ValueT]) startBatch(ctx context.Context) {
 	if l.batch == nil {
 		batch := &loaderBatch[KeyT, ValueT]{


### PR DESCRIPTION
fix #20

I implemented a `ClearAll()` method and enabled its corresponding test case.

Specifically:

*   I added a `ClearAll()` method to the `Loader` struct in `dataloadgen.go`.
    *   This method clears all cached values by re-initializing the `l.thunkCache` map to an empty one. This approach is more efficient than iterating and deleting each entry.
    *   I ensured thread safety by wrapping the cache clearing operation with `l.mu.Lock()` and `l.mu.Unlock()`, mirroring the pattern used by the existing `Clear(key)` method.
    *   I placed the new method immediately after `Clear(key)` for logical organization.
*   I modified `dataloader_test.go` to enable the existing `ClearAll` test case within `TestLoader`.
    *   I removed `t.Skip("not supported yet")` and uncommented the `identityLoader.ClearAll()` call.
    *   This allowed the test to run and verify the functionality of the newly added `ClearAll()` method.

The `ClearAll()` method now correctly clears all cached entries, forcing subsequent loads to fetch fresh data. The specific test for `ClearAll` passed successfully, confirming its functionality. I noted that other unrelated test failures were pre-existing issues with `TestMappedLoader` and not introduced by these changes.